### PR TITLE
chore: split anvil/allo containers; update image; unblock foundry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules
 .openzeppelin*
 .upgradable
 .vscode
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,12 @@ RUN apt-get update && \
 COPY . /app
 WORKDIR /app
 
-
-# Check when foundry supports dumping events
-# https://github.com/foundry-rs/foundry/issues/5906
-RUN curl -L https://foundry.paradigm.xyz | bash
-
-RUN ~/.foundry/bin/foundryup
-
 ENV PATH="$PNPM_HOME:$PATH"
 
 RUN corepack enable
 RUN pnpm install
 
-FROM node:16-bullseye-slim as prod
+FROM node:20-slim as prod
 RUN apt-get update && \
     apt-get install -y curl git && \
     apt-get clean  -y && \
@@ -28,7 +21,6 @@ COPY . /app
 WORKDIR /app
 
 COPY --from=base /app/node_modules /app/node_modules
-COPY --from=base /root/.foundry/bin/anvil /root/.foundry/bin/anvil
 
 ENV DEV_CHAIN_ID=313371
 ENV PNPM_HOME="/pnpm"
@@ -37,6 +29,4 @@ RUN corepack enable
 
 RUN pnpm hardhat compile
 
-EXPOSE 8545/tcp
-
-ENTRYPOINT ./docker/start-chain.sh
+ENTRYPOINT ./docker/deploy-contracts.sh

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,23 @@
 .PHONY: docker-build docker-run docker-kill docker-stop docker-logs docker-deploy-contracts docker-all
 
-IMAGE_NAME=allo
-CONTAINER_NAME=allo
-
 docker-all: docker-kill docker-build docker-run docker-deploy-contracts
 
 docker-build:
-		docker build . -t $(IMAGE_NAME) --no-cache --progress=plain
+		docker build . -t allo
 
 docker-run:
-		docker run --name $(CONTAINER_NAME) --rm -d -p 127.0.0.1:8545:8545/tcp $(IMAGE_NAME)
+		-docker network create allo-devenv-tmp-net
+		docker run --network allo-devenv-tmp-net --name localchain --rm -d -p 127.0.0.1:8545:8545/tcp ghcr.io/foundry-rs/foundry:latest "anvil --host 0.0.0.0 --chain-id 313371"
 
 docker-kill:
-		-docker kill $(CONTAINER_NAME)
+		-docker kill localchain
 
 docker-stop:
-		docker stop $(CONTAINER_NAME)
+		docker stop localchain
 
 docker-logs:
-		docker logs -f $(CONTAINER_NAME)
+		docker logs -f localchain
 
 docker-deploy-contracts:
-		docker exec allo bash ./docker/deploy-contracts.sh
+		docker run --network=allo-devenv-tmp-net -e DEV_CHAIN_HOST=localchain allo
+

--- a/docker/deploy-contracts.sh
+++ b/docker/deploy-contracts.sh
@@ -2,32 +2,33 @@ export SKIP_CONFIRMATIONS=true
 
 TIMEFORMAT='(🟢 %3R seconds)';
 
-time pnpm run deploy-project-registry dev && \
-time pnpm hardhat run scripts/dev/populate/projects.ts --network dev && \
+pnpm run deploy-project-registry dev && \
 \
-time pnpm run deploy-program-factory dev && \
-time pnpm run deploy-program-implementation dev && \
-time pnpm run link-program-implementation dev && \
+pnpm run deploy-program-factory dev && \
+pnpm run deploy-program-implementation dev && \
+pnpm run link-program-implementation dev && \
 \
-time pnpm run deploy-qf-factory dev && \
-time pnpm run deploy-qf-implementation dev && \
-time pnpm run link-qf-implementation dev && \
+pnpm hardhat run scripts/dev/populate/projects.ts --network dev && \
 \
-time pnpm run deploy-merkle-factory dev && \
-time pnpm run deploy-merkle-implementation dev && \
-time pnpm run link-merkle-implementation dev && \
+pnpm run deploy-qf-factory dev && \
+pnpm run deploy-qf-implementation dev && \
+pnpm run link-qf-implementation dev && \
 \
-time pnpm run deploy-direct-factory dev && \
-time pnpm run deploy-direct-implementation dev && \
-time pnpm run link-direct-implementation dev && \
+pnpm run deploy-merkle-factory dev && \
+pnpm run deploy-merkle-implementation dev && \
+pnpm run link-merkle-implementation dev && \
 \
-time pnpm run deploy-allo-settings dev && \
-time pnpm run set-protocol-fee dev && \
+pnpm run deploy-direct-factory dev && \
+pnpm run deploy-direct-implementation dev && \
+pnpm run link-direct-implementation dev && \
 \
-time pnpm run deploy-round-factory dev && \
-time pnpm run deploy-round-implementation dev && \
-time pnpm run link-round-implementation dev && \
-time pnpm run link-allo-settings dev
+pnpm run deploy-allo-settings dev && \
+pnpm run set-protocol-fee dev && \
+\
+pnpm run deploy-round-factory dev && \
+pnpm run deploy-round-implementation dev && \
+pnpm run link-round-implementation dev && \
+pnpm run link-allo-settings dev
 
 # pnpm run create-program dev
 # pnpm run create-qf-contract dev

--- a/docker/start-chain.sh
+++ b/docker/start-chain.sh
@@ -1,1 +1,0 @@
-~/.foundry/bin/anvil --host 0.0.0.0 --chain-id $DEV_CHAIN_ID


### PR DESCRIPTION
- upgrade openzeppelin/upgrades (see https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/943)
- upgrade to node version 20
- unblock tracking latest foundry
- use separate images for anvil and the allo deployer

Note: additional work needs to be done in https://github.com/gitcoinco/grants-stack/pull/2769